### PR TITLE
Add corrections to meet the official requirements

### DIFF
--- a/dithesis.cls
+++ b/dithesis.cls
@@ -158,6 +158,12 @@ headsep=0.5cm,footskip=0.75cm,
 \RequirePackage{longtable} % needed for splitting big tables across pages
 \RequirePackage{xifthen}
 \RequirePackage[caption=false]{subfig}
+\RequirePackage[%
+  font={footnotesize, bf},
+  justification=centering,
+  labelsep=colon,
+  figureposition=bottom,
+  tableposition=top]{caption} % captions
 
 %(e.g., abbreviations)
 %\RequirePackage[toc,page,titletoc]{appendix} % needed for configuring

--- a/dithesis.cls
+++ b/dithesis.cls
@@ -446,9 +446,13 @@ publications}\gdef\@lopfileinternal{#1}}
   \@abstractEn{}
   \vfill
 
-  {\bfseries SUBJECT AREA}: \@subjectAreaEn\\
+  \begin{tabularx}{\textwidth}{l X}
+    {\bfseries SUBJECT AREA:}  & \@subjectAreaEn
+  \end{tabularx}
 
-  {\bfseries KEYWORDS}: \@keywordsEn
+  \begin{tabularx}{\textwidth}{l X}
+    {\bfseries KEYWORDS:}  & \@keywordsEn
+  \end{tabularx}
 }
 
 %
@@ -462,9 +466,13 @@ publications}\gdef\@lopfileinternal{#1}}
   \end{greek}
   \vfill
 
-  {\bfseries ΘΕΜΑΤΙΚΗ ΠΕΡΙΟΧΗ}: \@subjectAreaGr\\
+  \begin{tabularx}{\textwidth}{l X}
+    {\bfseries ΘΕΜΑΤΙΚΗ ΠΕΡΙΟΧΗ:}  & \@subjectAreaGr
+  \end{tabularx}
 
-  {\bfseries ΛΕΞΕΙΣ ΚΛΕΙΔΙΑ}: \@keywordsGr
+  \begin{tabularx}{\textwidth}{l X}
+    {\bfseries ΛΕΞΕΙΣ ΚΛΕΙΔΙΑ:}  & \@keywordsGr
+  \end{tabularx}
 }
 
 %

--- a/dithesis.cls
+++ b/dithesis.cls
@@ -157,6 +157,7 @@ headsep=0.5cm,footskip=0.75cm,
 \RequirePackage{tabularx}  % needed for tabular* environment
 \RequirePackage{longtable} % needed for splitting big tables across pages
 \RequirePackage{xifthen}
+\RequirePackage[caption=false]{subfig}
 
 %(e.g., abbreviations)
 %\RequirePackage[toc,page,titletoc]{appendix} % needed for configuring
@@ -535,6 +536,53 @@ publications}\gdef\@lopfileinternal{#1}}
   \thispagestyle{empty}
   \clearpage
 }
+
+
+%%
+%% Format of Table of Contents, List of Figures and List of Tables.
+%% (Adapted from dithesis.cls made by Yannis Mantzouratos <mantzouratos@gmail.com>)
+%%
+\RequirePackage{titletoc}
+\RequirePackage[subfigure,titles]{tocloft}
+
+% Table of Contents
+\let\oldtableofcontents\tableofcontents
+\DeclareRobustCommand{\tableofcontents}{
+  \newpage
+  \pagestyle{empty}
+  \oldtableofcontents
+  \clearpage
+  \pagestyle{fancy}
+}
+
+% place dots between each section and the respective page number
+\renewcommand{\cftsecleader}{\bfseries\cftdotfill{\cftdotsep}}
+% place dots between each subsection and the respective page number
+\renewcommand{\cftsubsecleader}{\bfseries\cftdotfill{\cftdotsep}}
+
+% place a dot after each chapter number
+\renewcommand{\cftchapaftersnum}{.}
+
+% section entries should be 10 pt and bold
+\renewcommand{\cftsecfont}{\fontsize{10pt}{12pt}\selectfont\bfseries}
+% subsection entries should be 10 pt
+\renewcommand{\cftsubsecfont}{\fontsize{10pt}{12pt}\selectfont}
+% subsubsection entries should be 10 pt
+\renewcommand{\cftsubsubsecfont}{\fontsize{10pt}{12pt}\selectfont}
+
+% sections should not be indented, whereas subsections and subsubsections should
+\setlength\cftsubsubsecindent\cftsubsecindent
+\setlength\cftsubsecindent\cftsecindent
+\setlength{\cftsecindent}{0pt}
+
+% sections should have the same vertical space with chapters
+\setlength\cftbeforesecskip\cftbeforechapskip
+
+% space between chapters and numbering in case of double digit numbers
+\newlength{\tocbinnumwidth}
+\settowidth{\tocbinnumwidth}{9}
+\addtolength{\cftchapnumwidth}{\tocbinnumwidth}
+
 
 %
 % Configure the frontmatter page

--- a/dithesis.cls
+++ b/dithesis.cls
@@ -6,6 +6,7 @@
 %
 % Copyright (c) 2014, 2015 Charalampos S. Nikolaou <charnik@di.uoa.gr>
 %                     2017 Ergys Dona <errikosd@gmail.com>
+%                     2020 Giorgos Katsogiannis <geo.katsogiannis@gmail.com>
 %
 % This work may be distributed and/or modified under the conditions of the
 % LaTeX Project Public License. The latest version of this license is in
@@ -47,6 +48,11 @@
 %
 
 % Document Versions
+%
+% Version 1.3, 2020/10/02
+%   Added some corrections to match the department's official formatting requirements.
+%   Changes were applied to the acronyms table, the bibliography size, the table of
+%   contents, the captions of figures and tables and the abstract page's keywords.
 %
 % Version 1.2, 2017/02/26
 %   Refactored the document to allow it to be used to write BSc Theses.

--- a/references.bib
+++ b/references.bib
@@ -1,0 +1,17 @@
+@InProceedings{manning:corenlp,
+  author    = {Manning, Christopher D. and  Surdeanu, Mihai  and  Bauer, John  and  Finkel, Jenny  and  Bethard, Steven J. and  McClosky, David},
+  title     = {The {Stanford} {CoreNLP} Natural Language Processing Toolkit},
+  booktitle = {Association for Computational Linguistics (ACL) System Demonstrations},
+  year      = {2014},
+  pages     = {55--60},
+  url       = {http://www.aclweb.org/anthology/P/P14/P14-5010}
+}
+
+@inproceedings{pennington:glove,
+  author = {Jeffrey Pennington and Richard Socher and Christopher D. Manning},
+  booktitle = {Empirical Methods in Natural Language Processing (EMNLP)},
+  title = {GloVe: Global Vectors for Word Representation},
+  year = {2014},
+  pages = {1532--1543},
+  url = {http://www.aclweb.org/anthology/D14-1162},
+}

--- a/thesis.tex
+++ b/thesis.tex
@@ -116,8 +116,8 @@
 %
 \subjectAreaGr{Θεματική Περιοχή}
 \subjectAreaEn{Subject Area}
-\keywordsGr{Λέξη κλειδί1, λέξη κλειδί2, λέξη κλειδί3}
-\keywordsEn{Keyword1, keyword2, keyword3}
+\keywordsGr{Λέξη κλειδί1, λέξη κλειδί2, λέξη κλειδί3, λέξη κλειδί4, λέξη κλειδί5, λέξη κλειδί6}
+\keywordsEn{Keyword1, keyword2, keyword3, keyword4, keyword5, keyword6, keyword7}
 
 %
 % Set the .bib file containing your paper publications (leave the extension out)

--- a/thesis.tex
+++ b/thesis.tex
@@ -280,9 +280,33 @@
 
 \chapter{BACKGROUND AND RELATED WORK}
   \lipsum[4-7]
+  \begin{figure}
+    \centering
+    \includegraphics{emblems/athena-black}
+    \caption{The emblem picturing Athena}
+    \label{athena}
+  \end{figure}
 
 \chapter{ANOTHER CHAPTER}
   \lipsum[10-20]
+
+  \begin{table}
+    \centering
+
+    \caption{Some numbers in a table}
+    \label{numbers}
+
+    \begin{tabular}{| c | c |}
+      \hline
+      1 & one \\
+      \hline
+      2 & two \\
+      \hline
+      3 & three \\
+      \hline
+    \end{tabular}
+
+  \end{table}
 
 \chapter{CONCLUSIONS AND FUTURE WORK}
   \lipsum[3-5]

--- a/thesis.tex
+++ b/thesis.tex
@@ -310,6 +310,8 @@
 
 \chapter{CONCLUSIONS AND FUTURE WORK}
   \lipsum[3-5]
+  One reference to some paper \cite{manning:corenlp} and to another paper
+  \cite{pennington:glove}.
 
 \backmatter
 
@@ -343,7 +345,8 @@
 
 % manually include the bibliography
 \bibliographystyle{plain}
-\bibliography{references}
+{\footnotesize \bibliography{references}}
+
 % include it also in ToC (do sth on your own)
 \addcontentsline{toc}{chapter}{REFERENCES}
 

--- a/thesis.tex
+++ b/thesis.tex
@@ -319,13 +319,16 @@
 \abbreviations
 \begin{center}
 	\renewcommand{\arraystretch}{1.5}
-	\begin{longtable}{ l @{\qquad} l }
-	\toprule
+	\begin{longtable}{| l | @{\qquad} l |}
+	\hline
 	RDF    & Resource Description Framework \\
+  \hline
 	SPARQL & SPARQL Protocol and RDF Query Language \\
+  \hline
 	OWL    & Web Ontology Language \\
+  \hline
 	OGC    & Open Geospatial Consortium \\
-	\bottomrule
+	\hline
 	\end{longtable}
 \end{center}
 


### PR DESCRIPTION
I have added some small corrections that were required by the department when I submitted my thesis.
More specifically:
- When keywords take more than one row, the second row must start at the same point as the first
- Fix table of contents sizes and alignment
- The size of the bibliography references must be arial 10
- Acronyms table must have a complete grid
- Captions in figures and tables must be centered, bold, arial 10
